### PR TITLE
feat: add provider catalog API endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from routers import debates, websocket
+from routers import debates, providers, websocket
 from routers.debates import get_debate_manager
 from routers.websocket import setup_websocket_broadcasting
 
@@ -65,6 +65,7 @@ def health_check():
 
 # Mount routers
 app.include_router(debates.router)
+app.include_router(providers.router)
 app.include_router(websocket.router)
 
 logger.info("Routers mounted successfully")

--- a/backend/models/provider_catalog.py
+++ b/backend/models/provider_catalog.py
@@ -1,0 +1,46 @@
+"""Provider catalog models for listing available LLM providers and models."""
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from models.llm import ModelProvider
+
+
+class ModelInfo(BaseModel):
+    """Information about a specific LLM model."""
+
+    model_id: str = Field(
+        ..., description="Model identifier (e.g., 'claude-3-5-sonnet-20241022')"
+    )
+    display_name: str = Field(..., description="Human-readable name")
+    description: str = Field(..., description="Model description/capabilities")
+    context_window: int = Field(..., description="Token context window size")
+    max_output_tokens: int = Field(..., description="Maximum output tokens")
+    recommended: bool = Field(
+        default=False, description="Whether this is a recommended model"
+    )
+    pricing_tier: str = Field(
+        ..., description="Pricing tier (e.g., 'standard', 'premium')"
+    )
+
+
+class ProviderInfo(BaseModel):
+    """Information about an LLM provider."""
+
+    provider_id: ModelProvider = Field(..., description="Provider identifier")
+    display_name: str = Field(..., description="Provider display name")
+    description: str = Field(..., description="Provider description")
+    api_key_env_var: str = Field(
+        ..., description="Default environment variable for API key"
+    )
+    documentation_url: str = Field(..., description="Link to provider documentation")
+    models: List[ModelInfo] = Field(
+        ..., description="Available models from this provider"
+    )
+
+
+class ProviderCatalogResponse(BaseModel):
+    """Response containing all providers and their models."""
+
+    providers: List[ProviderInfo] = Field(..., description="List of all providers")

--- a/backend/routers/providers.py
+++ b/backend/routers/providers.py
@@ -1,0 +1,24 @@
+"""REST API endpoints for provider catalog management."""
+
+from fastapi import APIRouter
+
+from models.provider_catalog import ProviderCatalogResponse
+from services.provider_catalog import get_provider_catalog
+
+router = APIRouter(prefix="/api/providers", tags=["providers"])
+
+
+@router.get("", response_model=ProviderCatalogResponse)
+async def list_providers() -> ProviderCatalogResponse:
+    """
+    Get all available LLM providers and their models.
+
+    Returns a curated catalog of supported providers (Anthropic, OpenAI)
+    with detailed information about each available model including
+    context windows, output limits, and recommendations.
+
+    Returns:
+        Complete catalog of providers and models with metadata
+    """
+    providers = get_provider_catalog()
+    return ProviderCatalogResponse(providers=providers)

--- a/backend/services/provider_catalog.py
+++ b/backend/services/provider_catalog.py
@@ -1,0 +1,91 @@
+"""Static catalog service for LLM providers and models."""
+
+from typing import List
+
+from models.llm import ModelProvider
+from models.provider_catalog import ModelInfo, ProviderInfo
+
+
+# Static catalog of supported providers and models
+PROVIDER_CATALOG: List[ProviderInfo] = [
+    ProviderInfo(
+        provider_id=ModelProvider.ANTHROPIC,
+        display_name="Anthropic",
+        description="Claude models by Anthropic",
+        api_key_env_var="ANTHROPIC_API_KEY",
+        documentation_url="https://docs.anthropic.com/",
+        models=[
+            ModelInfo(
+                model_id="claude-3-5-sonnet-20241022",
+                display_name="Claude 3.5 Sonnet",
+                description="Most intelligent model, balanced performance and speed",
+                context_window=200000,
+                max_output_tokens=8192,
+                recommended=True,
+                pricing_tier="standard",
+            ),
+            ModelInfo(
+                model_id="claude-3-opus-20240229",
+                display_name="Claude 3 Opus",
+                description="Most powerful model for complex tasks",
+                context_window=200000,
+                max_output_tokens=4096,
+                recommended=False,
+                pricing_tier="premium",
+            ),
+        ],
+    ),
+    ProviderInfo(
+        provider_id=ModelProvider.OPENAI,
+        display_name="OpenAI",
+        description="GPT models by OpenAI",
+        api_key_env_var="OPENAI_API_KEY",
+        documentation_url="https://platform.openai.com/docs/",
+        models=[
+            ModelInfo(
+                model_id="gpt-4o",
+                display_name="GPT-4o",
+                description="Fastest and most affordable flagship model",
+                context_window=128000,
+                max_output_tokens=16384,
+                recommended=True,
+                pricing_tier="standard",
+            ),
+            ModelInfo(
+                model_id="gpt-4-turbo",
+                display_name="GPT-4 Turbo",
+                description="Previous generation, strong reasoning",
+                context_window=128000,
+                max_output_tokens=4096,
+                recommended=False,
+                pricing_tier="standard",
+            ),
+        ],
+    ),
+]
+
+
+def get_provider_catalog() -> List[ProviderInfo]:
+    """
+    Get the static provider catalog.
+
+    Returns:
+        List of all supported providers with their models
+    """
+    return PROVIDER_CATALOG
+
+
+def get_provider_by_id(provider_id: ModelProvider) -> ProviderInfo | None:
+    """
+    Get a specific provider by ID.
+
+    Args:
+        provider_id: Provider identifier to search for
+
+    Returns:
+        Provider information if found, None otherwise
+    """
+    for provider in PROVIDER_CATALOG:
+        if provider.provider_id == provider_id:
+            return provider
+    return None


### PR DESCRIPTION
Add new /api/providers endpoint that returns a static catalog of available LLM providers (Anthropic, OpenAI) and their models with detailed metadata including context windows, output limits, and recommendations.

New files:
- models/provider_catalog.py: Pydantic models for catalog responses
- services/provider_catalog.py: Static catalog with 4 models
- routers/providers.py: API router for /api/providers endpoint

Modified:
- main.py: Register providers router