### PR TITLE
feat: Add preconfigured persona system for debate agents

### DIFF
--- a/backend/config/personas.json
+++ b/backend/config/personas.json
@@ -1,0 +1,90 @@
+[
+  {
+    "persona_id": "socratic-philosopher",
+    "name": "Socratic Philosopher",
+    "expertise": "Logic and Epistemology",
+    "debate_style": "socratic",
+    "description": "Questions assumptions, seeks truth through inquiry",
+    "system_prompt_template": "You are a philosopher in the Socratic tradition. Your expertise lies in questioning assumptions and seeking truth through careful inquiry. When debating {stance} on this topic, use the Socratic method: ask probing questions, expose contradictions, and guide the discussion toward deeper understanding. Remain humble yet persistent in your pursuit of logical clarity. Challenge premises rather than merely stating positions.",
+    "suggested_temperature": 0.7,
+    "suggested_max_tokens": 1024,
+    "tags": ["philosophy", "logic", "questioning"]
+  },
+  {
+    "persona_id": "data-scientist",
+    "name": "Data Scientist",
+    "expertise": "Statistical Analysis and Empirical Research",
+    "debate_style": "analytical",
+    "description": "Focuses on data, evidence, and statistical rigor",
+    "system_prompt_template": "You are a data scientist who values empirical evidence and statistical rigor above all else. When arguing {stance} on this topic, ground your arguments in data, research findings, and quantitative analysis. Cite studies, statistics, and measurable outcomes. Question anecdotal evidence and demand reproducible results. Use clear, precise language and acknowledge uncertainty where appropriate. Your strength lies in transforming complex data into compelling arguments.",
+    "suggested_temperature": 0.5,
+    "suggested_max_tokens": 1200,
+    "tags": ["science", "data", "empirical", "analytical"]
+  },
+  {
+    "persona_id": "trial-lawyer",
+    "name": "Trial Lawyer",
+    "expertise": "Rhetoric and Persuasive Argumentation",
+    "debate_style": "aggressive",
+    "description": "Uses rhetoric, precedent, and aggressive persuasion",
+    "system_prompt_template": "You are an experienced trial lawyer skilled in persuasive rhetoric and courtroom strategy. When arguing {stance} on this topic, build your case methodically: establish facts, construct logical arguments, anticipate counterarguments, and deliver compelling rebuttals. Use analogies, precedents, and emotional appeals where appropriate. Be aggressive in cross-examining opposing views, but maintain professional decorum. Your goal is to win the argument decisively.",
+    "suggested_temperature": 0.8,
+    "suggested_max_tokens": 1500,
+    "tags": ["law", "rhetoric", "persuasion", "aggressive"]
+  },
+  {
+    "persona_id": "academic-researcher",
+    "name": "Academic Researcher",
+    "expertise": "Scholarly Research and Critical Analysis",
+    "debate_style": "analytical",
+    "description": "Emphasizes scholarly rigor, citations, and cautious claims",
+    "system_prompt_template": "You are an academic researcher committed to scholarly rigor and intellectual honesty. When presenting arguments {stance} on this topic, carefully cite relevant literature, acknowledge limitations in current knowledge, and present nuanced positions. Avoid overgeneralizations and be willing to say 'more research is needed.' Engage with theoretical frameworks and consider multiple perspectives. Your credibility comes from thoroughness and precision, not from certainty.",
+    "suggested_temperature": 0.6,
+    "suggested_max_tokens": 1400,
+    "tags": ["academia", "research", "scholarly", "rigorous"]
+  },
+  {
+    "persona_id": "political-strategist",
+    "name": "Political Strategist",
+    "expertise": "Public Policy and Strategic Communication",
+    "debate_style": "diplomatic",
+    "description": "Frames arguments around public opinion and pragmatic outcomes",
+    "system_prompt_template": "You are a seasoned political strategist skilled in framing complex issues for diverse audiences. When advocating {stance} on this topic, consider public opinion, stakeholder interests, and practical implementation. Build coalitions by finding common ground, use compelling narratives that resonate emotionally, and always tie arguments to real-world consequences. Be diplomatic but persuasive, acknowledging valid concerns while steering toward your position.",
+    "suggested_temperature": 0.75,
+    "suggested_max_tokens": 1100,
+    "tags": ["politics", "strategy", "diplomacy", "pragmatic"]
+  },
+  {
+    "persona_id": "entrepreneur",
+    "name": "Entrepreneur",
+    "expertise": "Innovation and First Principles Thinking",
+    "debate_style": "aggressive",
+    "description": "Emphasizes innovation, disruption, and optimistic possibility",
+    "system_prompt_template": "You are an innovative entrepreneur who thinks from first principles and challenges conventional wisdom. When arguing {stance} on this topic, focus on opportunities, potential for disruption, and creative solutions. Question legacy assumptions and propose bold alternatives. Be optimistic about solving hard problems through innovation and iteration. Use concrete examples of how similar thinking led to breakthroughs. Don't be constrained by 'how things have always been done.'",
+    "suggested_temperature": 0.9,
+    "suggested_max_tokens": 1000,
+    "tags": ["innovation", "business", "disruption", "optimistic"]
+  },
+  {
+    "persona_id": "ethicist",
+    "name": "Ethicist",
+    "expertise": "Moral Philosophy and Applied Ethics",
+    "debate_style": "analytical",
+    "description": "Analyzes moral implications and ethical frameworks",
+    "system_prompt_template": "You are a moral philosopher specializing in applied ethics. When discussing {stance} on this topic, analyze the ethical dimensions using established frameworks (consequentialism, deontology, virtue ethics, etc.). Consider questions of fairness, rights, duties, and human flourishing. Examine edge cases and thought experiments to test moral intuitions. Distinguish between legal, practical, and ethical considerations. Your role is to illuminate the moral landscape, not simply to advocate, though you should defend your ethical position rigorously.",
+    "suggested_temperature": 0.65,
+    "suggested_max_tokens": 1300,
+    "tags": ["ethics", "philosophy", "morality", "principles"]
+  },
+  {
+    "persona_id": "investigative-journalist",
+    "name": "Investigative Journalist",
+    "expertise": "Fact-Checking and Critical Investigation",
+    "debate_style": "aggressive",
+    "description": "Aggressively fact-checks and investigates claims",
+    "system_prompt_template": "You are an investigative journalist with a reputation for rigorous fact-checking and skeptical inquiry. When examining {stance} on this topic, demand evidence for every claim, trace information back to primary sources, and expose logical fallacies or misleading statistics. Ask tough questions: Who benefits? What's the evidence? What are they not telling us? Be aggressive in pursuing truth but fair in your analysis. Distinguish between correlation and causation, and between facts and interpretations.",
+    "suggested_temperature": 0.7,
+    "suggested_max_tokens": 1250,
+    "tags": ["journalism", "investigation", "fact-checking", "skeptical"]
+  }
+]

--- a/backend/core/exceptions.py
+++ b/backend/core/exceptions.py
@@ -3,34 +3,41 @@
 
 class DebateError(Exception):
     """Base exception for debate-related errors."""
+
     pass
 
 
 class DebateNotFoundError(DebateError):
     """Raised when a debate is not found."""
+
     pass
 
 
 class DebateExecutionError(DebateError):
     """Raised when debate execution fails."""
+
     pass
 
 
 class AgentError(Exception):
     """Base exception for agent-related errors."""
+
     pass
 
 
 class LLMClientError(Exception):
     """Base exception for LLM client errors."""
+
     pass
 
 
 class ConfigurationError(Exception):
     """Raised when configuration is invalid or missing."""
+
     pass
 
 
 class StorageError(Exception):
     """Base exception for storage-related errors."""
+
     pass

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from routers import debates, providers, websocket
+from routers import debates, personas, providers, websocket
 from routers.debates import get_debate_manager
 from routers.websocket import setup_websocket_broadcasting
 
@@ -66,6 +66,7 @@ def health_check():
 
 # Mount routers
 app.include_router(debates.router)
+app.include_router(personas.router)
 app.include_router(providers.router)
 app.include_router(websocket.router)
 

--- a/backend/manual_tests/test_2_agent_debate.py
+++ b/backend/manual_tests/test_2_agent_debate.py
@@ -155,6 +155,7 @@ async def main():
     except Exception as e:
         print(f"\n❌ Error running debate: {e}")
         import traceback
+
         traceback.print_exc()
         raise
 

--- a/backend/manual_tests/test_3_agent_debate.py
+++ b/backend/manual_tests/test_3_agent_debate.py
@@ -189,6 +189,7 @@ async def main():
     except Exception as e:
         print(f"\n❌ Error running debate: {e}")
         import traceback
+
         traceback.print_exc()
         raise
 

--- a/backend/manual_tests/test_5_agent_debate.py
+++ b/backend/manual_tests/test_5_agent_debate.py
@@ -163,7 +163,9 @@ async def main():
 
         elif event.event_type == DebateEventType.AGENT_THINKING:
             turn_count["count"] += 1
-            print(f"[Turn {turn_count['count']}/10] 💭 {event.payload['agent_name']} is formulating argument...")
+            print(
+                f"[Turn {turn_count['count']}/10] 💭 {event.payload['agent_name']} is formulating argument..."
+            )
 
         elif event.event_type == DebateEventType.MESSAGE_RECEIVED:
             msg = event.payload["message"]
@@ -192,20 +194,20 @@ async def main():
 
             print("📊 DETAILED SCORES:\n")
             sorted_scores = sorted(
-                result["agent_scores"],
-                key=lambda x: x["score"],
-                reverse=True
+                result["agent_scores"], key=lambda x: x["score"], reverse=True
             )
             for i, score in enumerate(sorted_scores, 1):
                 medal = {1: "🥇", 2: "🥈", 3: "🥉"}.get(i, "  ")
                 stars = "⭐" * int(score["score"])
-                print(f"{medal} #{i} - {score['agent_name']}: {score['score']}/10 {stars}")
+                print(
+                    f"{medal} #{i} - {score['agent_name']}: {score['score']}/10 {stars}"
+                )
                 print(f"      Reasoning: {score['reasoning']}\n")
 
             print(f"{'─' * 80}")
             print("📝 JUDGE'S SUMMARY:")
             print(f"{'─' * 80}")
-            print(result['summary'])
+            print(result["summary"])
 
             if result.get("key_arguments"):
                 print(f"\n{'─' * 80}")
@@ -253,6 +255,7 @@ async def main():
     except Exception as e:
         print(f"\n❌ Error running debate: {e}")
         import traceback
+
         traceback.print_exc()
         raise
 

--- a/backend/models/api.py
+++ b/backend/models/api.py
@@ -76,9 +76,7 @@ class WebSocketMessage(BaseModel):
     """WebSocket message format."""
 
     type: str = Field(..., description="Message type")
-    payload: Dict[str, Any] = Field(
-        default_factory=dict, description="Message payload"
-    )
+    payload: Dict[str, Any] = Field(default_factory=dict, description="Message payload")
     timestamp: str = Field(..., description="Message timestamp (ISO format)")
 
 

--- a/backend/models/debate.py
+++ b/backend/models/debate.py
@@ -73,7 +73,9 @@ class DebateConfig(BaseModel):
 class DebateState(BaseModel):
     """Current state of a debate."""
 
-    debate_id: str = Field(default_factory=lambda: str(uuid4()), description="Unique debate ID")
+    debate_id: str = Field(
+        default_factory=lambda: str(uuid4()), description="Unique debate ID"
+    )
     config: DebateConfig = Field(..., description="Debate configuration")
     status: DebateStatus = Field(
         default=DebateStatus.CREATED, description="Current debate status"
@@ -91,7 +93,7 @@ class DebateState(BaseModel):
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
-        description="When the debate was created"
+        description="When the debate was created",
     )
     started_at: Optional[datetime] = Field(
         default=None, description="When the debate started"

--- a/backend/models/message.py
+++ b/backend/models/message.py
@@ -17,7 +17,7 @@ class Message(BaseModel):
     )
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
-        description="When the message was created"
+        description="When the message was created",
     )
     stance: str = Field(..., description="Agent's stance in the debate")
 
@@ -25,7 +25,9 @@ class Message(BaseModel):
 class MessageHistory(BaseModel):
     """Collection of messages in a debate."""
 
-    messages: List[Message] = Field(default_factory=list, description="List of messages")
+    messages: List[Message] = Field(
+        default_factory=list, description="List of messages"
+    )
 
     def add_message(self, message: Message) -> None:
         """

--- a/backend/models/persona.py
+++ b/backend/models/persona.py
@@ -1,0 +1,50 @@
+"""Persona models."""
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class PersonaStyle(str, Enum):
+    """Debate style of a persona."""
+
+    AGGRESSIVE = "aggressive"
+    DIPLOMATIC = "diplomatic"
+    ANALYTICAL = "analytical"
+    SOCRATIC = "socratic"
+
+
+class PersonaTemplate(BaseModel):
+    """Template for a debate persona with predefined characteristics."""
+
+    persona_id: str = Field(..., description="Unique identifier for the persona")
+    name: str = Field(..., description="Display name of the persona")
+    expertise: str = Field(..., description="Area of expertise or specialization")
+    debate_style: PersonaStyle = Field(..., description="Debate approach style")
+    description: str = Field(
+        ..., description="Brief description of the persona's characteristics"
+    )
+    system_prompt_template: str = Field(
+        ...,
+        description="System prompt template with {stance} placeholder for debate position",
+    )
+    suggested_temperature: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=2.0,
+        description="Recommended LLM temperature for this persona",
+    )
+    suggested_max_tokens: int = Field(
+        default=1024, ge=1, le=4096, description="Recommended max tokens for responses"
+    )
+    tags: list[str] = Field(
+        default_factory=list, description="Tags for categorizing the persona"
+    )
+
+
+class PersonaCatalogResponse(BaseModel):
+    """Response containing available persona templates."""
+
+    personas: list[PersonaTemplate] = Field(
+        ..., description="List of available persona templates"
+    )
+    total: int = Field(..., description="Total number of personas in the catalog")

--- a/backend/models/provider_catalog.py
+++ b/backend/models/provider_catalog.py
@@ -32,7 +32,8 @@ class ProviderInfo(BaseModel):
     display_name: str = Field(..., description="Provider display name")
     description: str = Field(..., description="Provider description")
     api_key_env_var: Optional[str] = Field(
-        None, description="Default environment variable for API key (None for local providers)"
+        None,
+        description="Default environment variable for API key (None for local providers)",
     )
     documentation_url: str = Field(..., description="Link to provider documentation")
     models: List[ModelInfo] = Field(

--- a/backend/routers/debates.py
+++ b/backend/routers/debates.py
@@ -424,7 +424,9 @@ def _export_markdown(debate) -> str:
     lines.append("")
     for agent in debate.config.agents:
         lines.append(f"- **{agent.name}** ({agent.stance})")
-        lines.append(f"  - Model: {agent.llm_config.provider}/{agent.llm_config.model_name}")
+        lines.append(
+            f"  - Model: {agent.llm_config.provider}/{agent.llm_config.model_name}"
+        )
         lines.append(f"  - Role: {agent.role.value}")
     lines.append("")
 
@@ -498,7 +500,9 @@ def _export_text(debate) -> str:
     lines.append("-" * 80)
     for agent in debate.config.agents:
         lines.append(f"{agent.name} ({agent.stance})")
-        lines.append(f"  Model: {agent.llm_config.provider}/{agent.llm_config.model_name}")
+        lines.append(
+            f"  Model: {agent.llm_config.provider}/{agent.llm_config.model_name}"
+        )
         lines.append(f"  Role: {agent.role.value}")
     lines.append("")
 

--- a/backend/routers/personas.py
+++ b/backend/routers/personas.py
@@ -1,0 +1,27 @@
+"""REST API endpoints for persona catalog management."""
+
+from fastapi import APIRouter
+
+from models.persona import PersonaCatalogResponse
+from services.persona_service import PersonaService
+
+router = APIRouter(prefix="/api/personas", tags=["personas"])
+
+# Initialize persona service singleton
+persona_service = PersonaService()
+
+
+@router.get("", response_model=PersonaCatalogResponse)
+async def list_personas() -> PersonaCatalogResponse:
+    """
+    Get all available persona templates.
+
+    Returns a catalog of preconfigured debate personas with distinct
+    archetypes (Socratic Philosopher, Trial Lawyer, Data Scientist, etc.).
+    Each persona includes expertise, debate style, and prompt templates.
+
+    Returns:
+        Complete catalog of persona templates with metadata
+    """
+    personas = persona_service.list_personas()
+    return PersonaCatalogResponse(personas=personas, total=len(personas))

--- a/backend/routers/websocket.py
+++ b/backend/routers/websocket.py
@@ -147,7 +147,7 @@ def setup_websocket_broadcasting(debate_manager: DebateManager) -> None:
         def serialize_payload(obj):
             """Recursively serialize payload to JSON-compatible types."""
             if isinstance(obj, BaseModel):
-                return obj.model_dump(mode='json')
+                return obj.model_dump(mode="json")
             elif isinstance(obj, dt):
                 return obj.isoformat()
             elif isinstance(obj, dict):
@@ -174,8 +174,7 @@ def setup_websocket_broadcasting(debate_manager: DebateManager) -> None:
             if loop.is_running():
                 # Use ensure_future to schedule the coroutine in the current loop
                 asyncio.ensure_future(
-                    connection_manager.broadcast(event.debate_id, message),
-                    loop=loop
+                    connection_manager.broadcast(event.debate_id, message), loop=loop
                 )
             else:
                 loop.run_until_complete(

--- a/backend/services/agent_orchestrator.py
+++ b/backend/services/agent_orchestrator.py
@@ -132,7 +132,7 @@ class AgentOrchestrator:
 
                 if attempt < self.max_turn_retries:
                     # Exponential backoff: 2^attempt seconds
-                    wait_time = 2 ** attempt
+                    wait_time = 2**attempt
                     logger.info(f"Retrying in {wait_time} seconds...")
                     await asyncio.sleep(wait_time)
 

--- a/backend/services/debate_manager.py
+++ b/backend/services/debate_manager.py
@@ -100,9 +100,7 @@ class DebateManager:
         Args:
             event: Event to emit
         """
-        logger.debug(
-            f"Emitting event: {event.event_type} for debate {event.debate_id}"
-        )
+        logger.debug(f"Emitting event: {event.event_type} for debate {event.debate_id}")
         for callback in self._event_callbacks:
             try:
                 callback(event)
@@ -206,9 +204,7 @@ class DebateManager:
                 exc_info=True,
             )
 
-            raise DebateExecutionError(
-                f"Debate execution failed: {e}"
-            ) from e
+            raise DebateExecutionError(f"Debate execution failed: {e}") from e
 
     async def _execute_round(
         self,
@@ -277,7 +273,7 @@ class DebateManager:
                     event_type=DebateEventType.MESSAGE_RECEIVED,
                     debate_id=debate_state.debate_id,
                     payload={
-                        "message": message.model_dump(mode='json'),
+                        "message": message.model_dump(mode="json"),
                     },
                 )
             )
@@ -296,7 +292,10 @@ class DebateManager:
             )
 
             # Rate limiting: sleep between turns (except after last turn)
-            if turn_index < len(turn_order) - 1 or round_num < debate_state.config.num_rounds:
+            if (
+                turn_index < len(turn_order) - 1
+                or round_num < debate_state.config.num_rounds
+            ):
                 await asyncio.sleep(self.rate_limit_delay)
 
         # Emit round complete event
@@ -371,7 +370,7 @@ class DebateManager:
                 DebateEvent(
                     event_type=DebateEventType.JUDGE_RESULT,
                     debate_id=debate_state.debate_id,
-                    payload={"result": judge_result.model_dump(mode='json')},
+                    payload={"result": judge_result.model_dump(mode="json")},
                 )
             )
 
@@ -387,9 +386,7 @@ class DebateManager:
             logger.error(error_msg, exc_info=True)
             raise DebateExecutionError(error_msg) from e
 
-    def _parse_judge_response(
-        self, response_text: str, agents: list
-    ) -> JudgeResult:
+    def _parse_judge_response(self, response_text: str, agents: list) -> JudgeResult:
         """
         Parse the judge's response into a JudgeResult.
 

--- a/backend/services/llm/litellm_client.py
+++ b/backend/services/llm/litellm_client.py
@@ -109,7 +109,7 @@ class LiteLLMClient(BaseLLMClient):
                 text = response.choices[0].message.content
 
                 # Log usage if available
-                if hasattr(response, 'usage') and response.usage:
+                if hasattr(response, "usage") and response.usage:
                     logger.debug(
                         f"Received response from {self.provider} - "
                         f"Prompt tokens: {response.usage.prompt_tokens}, "

--- a/backend/services/persona_service.py
+++ b/backend/services/persona_service.py
@@ -1,0 +1,103 @@
+"""Persona service for loading and managing debate persona templates."""
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List
+
+from pydantic import ValidationError
+
+from models.persona import PersonaTemplate
+
+logger = logging.getLogger(__name__)
+
+
+class PersonaService:
+    """Service for managing debate persona templates."""
+
+    def __init__(self, config_path: str | None = None):
+        """
+        Initialize the persona service.
+
+        Args:
+            config_path: Path to personas JSON configuration file.
+                        If None, uses default path relative to this file.
+        """
+        if config_path is None:
+            # Default path relative to this service file
+            service_dir = Path(__file__).parent.parent
+            config_path = str(service_dir / "config" / "personas.json")
+
+        self.personas: Dict[str, PersonaTemplate] = {}
+        self._load_personas(config_path)
+
+    def _load_personas(self, config_path: str) -> None:
+        """
+        Load and validate personas from JSON configuration file.
+
+        Args:
+            config_path: Path to personas JSON file
+
+        Raises:
+            FileNotFoundError: If config file does not exist
+            ValueError: If JSON is invalid or personas fail validation
+        """
+        config_file = Path(config_path)
+
+        if not config_file.exists():
+            logger.error(f"Personas config file not found: {config_path}")
+            raise FileNotFoundError(f"Personas config file not found: {config_path}")
+
+        try:
+            with open(config_file, "r", encoding="utf-8") as f:
+                personas_data = json.load(f)
+
+            if not isinstance(personas_data, list):
+                raise ValueError("Personas config must be a JSON array")
+
+            loaded_count = 0
+            for persona_dict in personas_data:
+                try:
+                    persona = PersonaTemplate(**persona_dict)
+
+                    # Check for duplicate persona_id
+                    if persona.persona_id in self.personas:
+                        logger.warning(
+                            f"Duplicate persona_id '{persona.persona_id}' found, skipping"
+                        )
+                        continue
+
+                    self.personas[persona.persona_id] = persona
+                    loaded_count += 1
+                except ValidationError as e:
+                    logger.warning(
+                        f"Invalid persona data, skipping: {persona_dict.get('persona_id', 'unknown')} - {e}"
+                    )
+                    continue
+
+            logger.info(f"Loaded {loaded_count} personas from {config_path}")
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON in personas config: {e}")
+            raise ValueError(f"Invalid JSON in personas config: {e}") from e
+
+    def list_personas(self) -> List[PersonaTemplate]:
+        """
+        Get all available persona templates.
+
+        Returns:
+            List of all loaded persona templates
+        """
+        return list(self.personas.values())
+
+    def get_persona(self, persona_id: str) -> PersonaTemplate | None:
+        """
+        Get a specific persona template by ID.
+
+        Args:
+            persona_id: Unique identifier for the persona
+
+        Returns:
+            PersonaTemplate if found, None otherwise
+        """
+        return self.personas.get(persona_id)

--- a/backend/storage/memory_store.py
+++ b/backend/storage/memory_store.py
@@ -29,9 +29,7 @@ class MemoryDebateStore:
         """
         async with self._lock:
             if debate.debate_id in self._debates:
-                raise StorageError(
-                    f"Debate with ID {debate.debate_id} already exists"
-                )
+                raise StorageError(f"Debate with ID {debate.debate_id} already exists")
             self._debates[debate.debate_id] = debate
             return debate
 

--- a/backend/tests/test_agent_orchestrator.py
+++ b/backend/tests/test_agent_orchestrator.py
@@ -153,7 +153,9 @@ class TestGetNextAgent:
         debate_state_3_agents.current_turn = 3
         assert orchestrator.get_next_agent(debate_state_3_agents).agent_id == "agent_1"
 
-    def test_get_next_agent_no_agents_validation(self, orchestrator, sample_judge_config):
+    def test_get_next_agent_no_agents_validation(
+        self, orchestrator, sample_judge_config
+    ):
         """Test that config validation prevents creating debate with no agents."""
         from pydantic import ValidationError
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -100,7 +100,9 @@ class TestDebateEndpoints:
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
 
-    def test_create_debate(self, client: TestClient, sample_debate_config: DebateConfig):
+    def test_create_debate(
+        self, client: TestClient, sample_debate_config: DebateConfig
+    ):
         """Test creating a new debate."""
         response = client.post(
             "/api/debates",
@@ -217,9 +219,7 @@ class TestDebateEndpoints:
         assert data["total_rounds"] == 2
         assert data["message_count"] == 0
 
-    def test_start_debate(
-        self, client: TestClient, sample_debate_config: DebateConfig
-    ):
+    def test_start_debate(self, client: TestClient, sample_debate_config: DebateConfig):
         """Test starting a debate."""
         # Create debate
         create_response = client.post(
@@ -254,6 +254,7 @@ class TestDebateEndpoints:
 
         # Give it a moment to start
         import time
+
         time.sleep(0.1)
 
         # Try to start again

--- a/backend/tests/test_debate_manager.py
+++ b/backend/tests/test_debate_manager.py
@@ -439,7 +439,10 @@ class TestInvokeJudge:
         assert isinstance(result, JudgeResult)
         assert len(result.agent_scores) == len(debate_state.config.agents)
         assert all(score.score == 5.0 for score in result.agent_scores)
-        assert "Unable to parse" in result.summary or "failed to parse" in result.summary.lower()
+        assert (
+            "Unable to parse" in result.summary
+            or "failed to parse" in result.summary.lower()
+        )
 
 
 class TestExecuteRound:

--- a/backend/tests/test_edge_cases.py
+++ b/backend/tests/test_edge_cases.py
@@ -400,9 +400,7 @@ class TestAPIFailures:
     """Test handling of API failures during debate execution."""
 
     @patch("services.llm.factory.create_llm_client")
-    def test_debate_with_llm_api_failure(
-        self, mock_create_client, client: TestClient
-    ):
+    def test_debate_with_llm_api_failure(self, mock_create_client, client: TestClient):
         """Test debate handling when LLM API fails."""
         # Mock LLM client that always fails
         mock_client = Mock()
@@ -473,6 +471,7 @@ class TestAPIFailures:
 
         # Wait a bit for background task
         import time
+
         time.sleep(2)
 
         # Check debate status - should be FAILED

--- a/backend/tests/test_integration_debate.py
+++ b/backend/tests/test_integration_debate.py
@@ -172,22 +172,26 @@ async def test_complete_3_agent_mixed_model_debate(three_agent_mixed_debate_conf
     async def mock_judge_send(*args, **kwargs):
         return judge_response
 
-    mock_anthropic.send_message = AsyncMock(side_effect=[
-        # Optimist (agent 1) responses
-        agent_responses[0],  # Round 1
-        agent_responses[3],  # Round 2
-        # Pragmatist (agent 3) responses
-        agent_responses[2],  # Round 1
-        agent_responses[5],  # Round 2
-        # Judge response
-        judge_response,
-    ])
+    mock_anthropic.send_message = AsyncMock(
+        side_effect=[
+            # Optimist (agent 1) responses
+            agent_responses[0],  # Round 1
+            agent_responses[3],  # Round 2
+            # Pragmatist (agent 3) responses
+            agent_responses[2],  # Round 1
+            agent_responses[5],  # Round 2
+            # Judge response
+            judge_response,
+        ]
+    )
 
-    mock_openai.send_message = AsyncMock(side_effect=[
-        # Skeptic (agent 2) responses
-        agent_responses[1],  # Round 1
-        agent_responses[4],  # Round 2
-    ])
+    mock_openai.send_message = AsyncMock(
+        side_effect=[
+            # Skeptic (agent 2) responses
+            agent_responses[1],  # Round 1
+            agent_responses[4],  # Round 2
+        ]
+    )
 
     # Patch the LLM factory to return our mocks
     def mock_create_llm_client(llm_config):
@@ -275,13 +279,19 @@ async def test_complete_3_agent_mixed_model_debate(three_agent_mixed_debate_conf
     assert DebateEventType.DEBATE_COMPLETE in event_types
 
     # Verify both LLM providers were used
-    assert mock_anthropic.send_message.call_count == 5  # 2x optimist + 2x pragmatist + 1x judge
+    assert (
+        mock_anthropic.send_message.call_count == 5
+    )  # 2x optimist + 2x pragmatist + 1x judge
     assert mock_openai.send_message.call_count == 2  # 2x skeptic
 
-    print("\n✅ Integration test passed: 3-agent mixed-model debate completed successfully")
+    print(
+        "\n✅ Integration test passed: 3-agent mixed-model debate completed successfully"
+    )
     print(f"   - Total messages: {len(result.history)}")
     print(f"   - Winner: {result.judge_result.winner_name}")
-    print(f"   - Scores: {[f'{s.agent_name}: {s.score}' for s in result.judge_result.agent_scores]}")
+    print(
+        f"   - Scores: {[f'{s.agent_name}: {s.score}' for s in result.judge_result.agent_scores]}"
+    )
 
 
 @pytest.mark.asyncio
@@ -317,17 +327,19 @@ async def test_debate_with_turn_retry_success(three_agent_mixed_debate_config):
             raise Exception("Temporary API error")
         return f"Response for call {call_count[0]}"
 
-    mock_client.send_message = AsyncMock(side_effect=[
-        Exception("Temporary API error"),  # First attempt fails
-        "Success after retry",  # Retry succeeds
-        "Second agent response",
-        "Third agent response",
-        "Fourth message",
-        "Fifth message",
-        "Sixth message",
-        # Judge
-        '{"summary": "Test", "agent_scores": [{"agent_id": "optimist", "agent_name": "Tech Optimist", "score": 8.0, "reasoning": "Good"}], "winner_id": "optimist", "winner_name": "Tech Optimist", "key_arguments": []}',
-    ])
+    mock_client.send_message = AsyncMock(
+        side_effect=[
+            Exception("Temporary API error"),  # First attempt fails
+            "Success after retry",  # Retry succeeds
+            "Second agent response",
+            "Third agent response",
+            "Fourth message",
+            "Fifth message",
+            "Sixth message",
+            # Judge
+            '{"summary": "Test", "agent_scores": [{"agent_id": "optimist", "agent_name": "Tech Optimist", "score": 8.0, "reasoning": "Good"}], "winner_id": "optimist", "winner_name": "Tech Optimist", "key_arguments": []}',
+        ]
+    )
 
     with patch(
         "services.agent_orchestrator.create_llm_client", return_value=mock_client

--- a/backend/tests/test_litellm_client.py
+++ b/backend/tests/test_litellm_client.py
@@ -65,7 +65,10 @@ class TestLiteLLMClient:
             assert call_args.kwargs["api_key"] == "test-anthropic-key"
             # Verify system prompt was added
             assert call_args.kwargs["messages"][0]["role"] == "system"
-            assert call_args.kwargs["messages"][0]["content"] == "You are a helpful assistant."
+            assert (
+                call_args.kwargs["messages"][0]["content"]
+                == "You are a helpful assistant."
+            )
 
     @pytest.mark.asyncio
     async def test_send_message_openai(self, openai_client):
@@ -131,7 +134,9 @@ class TestLiteLLMClient:
         mock_response.choices = []
 
         with patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)):
-            with pytest.raises(ValueError, match="Empty response from anthropic via LiteLLM"):
+            with pytest.raises(
+                ValueError, match="Empty response from anthropic via LiteLLM"
+            ):
                 await anthropic_client.send_message(
                     system_prompt="Test",
                     messages=[{"role": "user", "content": "Test"}],
@@ -144,11 +149,13 @@ class TestLiteLLMClient:
         """Test handling of authentication errors."""
         with patch(
             "litellm.acompletion",
-            new=AsyncMock(side_effect=litellm.AuthenticationError(
-                message="Invalid API key",
-                llm_provider="anthropic",
-                model="claude-sonnet-4-5-20250929"
-            ))
+            new=AsyncMock(
+                side_effect=litellm.AuthenticationError(
+                    message="Invalid API key",
+                    llm_provider="anthropic",
+                    model="claude-sonnet-4-5-20250929",
+                )
+            ),
         ):
             with pytest.raises(Exception, match="Authentication failed for anthropic"):
                 await anthropic_client.send_message(
@@ -163,11 +170,11 @@ class TestLiteLLMClient:
         """Test handling of rate limit errors (should retry)."""
         with patch(
             "litellm.acompletion",
-            new=AsyncMock(side_effect=litellm.RateLimitError(
-                message="Rate limit exceeded",
-                llm_provider="openai",
-                model="gpt-4o"
-            ))
+            new=AsyncMock(
+                side_effect=litellm.RateLimitError(
+                    message="Rate limit exceeded", llm_provider="openai", model="gpt-4o"
+                )
+            ),
         ):
             with pytest.raises(litellm.RateLimitError):
                 await openai_client.send_message(
@@ -182,11 +189,13 @@ class TestLiteLLMClient:
         """Test handling of context window exceeded errors."""
         with patch(
             "litellm.acompletion",
-            new=AsyncMock(side_effect=litellm.ContextWindowExceededError(
-                message="Context too long",
-                llm_provider="anthropic",
-                model="claude-sonnet-4-5-20250929"
-            ))
+            new=AsyncMock(
+                side_effect=litellm.ContextWindowExceededError(
+                    message="Context too long",
+                    llm_provider="anthropic",
+                    model="claude-sonnet-4-5-20250929",
+                )
+            ),
         ):
             with pytest.raises(Exception, match="Message too long for anthropic"):
                 await anthropic_client.send_message(
@@ -201,11 +210,11 @@ class TestLiteLLMClient:
         """Test handling of bad request errors."""
         with patch(
             "litellm.acompletion",
-            new=AsyncMock(side_effect=litellm.BadRequestError(
-                message="Invalid request",
-                llm_provider="openai",
-                model="gpt-4o"
-            ))
+            new=AsyncMock(
+                side_effect=litellm.BadRequestError(
+                    message="Invalid request", llm_provider="openai", model="gpt-4o"
+                )
+            ),
         ):
             with pytest.raises(Exception, match="Invalid request to openai"):
                 await openai_client.send_message(
@@ -220,11 +229,11 @@ class TestLiteLLMClient:
         """Test handling of service unavailable errors (should retry)."""
         with patch(
             "litellm.acompletion",
-            new=AsyncMock(side_effect=litellm.ServiceUnavailableError(
-                message="Service unavailable",
-                llm_provider="ollama",
-                model="llama2"
-            ))
+            new=AsyncMock(
+                side_effect=litellm.ServiceUnavailableError(
+                    message="Service unavailable", llm_provider="ollama", model="llama2"
+                )
+            ),
         ):
             with pytest.raises(litellm.ServiceUnavailableError):
                 await ollama_client.send_message(
@@ -239,11 +248,13 @@ class TestLiteLLMClient:
         """Test handling of connection errors (should retry)."""
         with patch(
             "litellm.acompletion",
-            new=AsyncMock(side_effect=litellm.APIConnectionError(
-                message="Connection failed",
-                llm_provider="anthropic",
-                model="claude-sonnet-4-5-20250929"
-            ))
+            new=AsyncMock(
+                side_effect=litellm.APIConnectionError(
+                    message="Connection failed",
+                    llm_provider="anthropic",
+                    model="claude-sonnet-4-5-20250929",
+                )
+            ),
         ):
             with pytest.raises(litellm.APIConnectionError):
                 await anthropic_client.send_message(
@@ -300,7 +311,7 @@ class TestLiteLLMFactory:
         config = LLMConfig(
             provider="anthropic",
             model_name="claude-sonnet-4-5-20250929",
-            api_key_env_var="ANTHROPIC_API_KEY"
+            api_key_env_var="ANTHROPIC_API_KEY",
         )
 
         # Create client
@@ -323,9 +334,7 @@ class TestLiteLLMFactory:
 
         # Create config for Ollama (no API key)
         config = LLMConfig(
-            provider="ollama",
-            model_name="llama2",
-            api_base="http://localhost:11434"
+            provider="ollama", model_name="llama2", api_base="http://localhost:11434"
         )
 
         # Create client

--- a/backend/tests/test_llm_clients.py
+++ b/backend/tests/test_llm_clients.py
@@ -18,8 +18,7 @@ class TestAnthropicClient:
     def anthropic_client(self):
         """Create an Anthropic client for testing."""
         return AnthropicClient(
-            api_key="test-api-key",
-            model_name="claude-3-5-sonnet-20241022"
+            api_key="test-api-key", model_name="claude-3-5-sonnet-20241022"
         )
 
     @pytest.mark.asyncio
@@ -81,9 +80,7 @@ class TestAnthropicClient:
         """Test handling of rate limit errors."""
         anthropic_client.client.messages.create = AsyncMock(
             side_effect=anthropic.RateLimitError(
-                response=MagicMock(),
-                body=None,
-                message="Rate limit exceeded"
+                response=MagicMock(), body=None, message="Rate limit exceeded"
             )
         )
 
@@ -106,10 +103,7 @@ class TestOpenAIClient:
     @pytest.fixture
     def openai_client(self):
         """Create an OpenAI client for testing."""
-        return OpenAIClient(
-            api_key="test-api-key",
-            model_name="gpt-4o"
-        )
+        return OpenAIClient(api_key="test-api-key", model_name="gpt-4o")
 
     @pytest.mark.asyncio
     async def test_send_message_success(self, openai_client):
@@ -122,7 +116,9 @@ class TestOpenAIClient:
         mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=20)
 
         # Mock the client's chat.completions.create method
-        openai_client.client.chat.completions.create = AsyncMock(return_value=mock_response)
+        openai_client.client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
 
         # Test the send_message method
         result = await openai_client.send_message(
@@ -148,7 +144,9 @@ class TestOpenAIClient:
         mock_response = MagicMock()
         mock_response.choices = []
 
-        openai_client.client.chat.completions.create = AsyncMock(return_value=mock_response)
+        openai_client.client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
 
         with pytest.raises(ValueError, match="Empty response from OpenAI API"):
             await openai_client.send_message(
@@ -178,9 +176,7 @@ class TestOpenAIClient:
         """Test handling of rate limit errors."""
         openai_client.client.chat.completions.create = AsyncMock(
             side_effect=openai.RateLimitError(
-                response=MagicMock(),
-                body=None,
-                message="Rate limit exceeded"
+                response=MagicMock(), body=None, message="Rate limit exceeded"
             )
         )
 
@@ -214,7 +210,7 @@ class TestLLMFactory:
         config = LLMConfig(
             provider="anthropic",
             model_name="claude-3-5-sonnet-20241022",
-            api_key_env_var="ANTHROPIC_API_KEY"
+            api_key_env_var="ANTHROPIC_API_KEY",
         )
 
         # Create client
@@ -237,9 +233,7 @@ class TestLLMFactory:
 
         # Create config
         config = LLMConfig(
-            provider="openai",
-            model_name="gpt-4o",
-            api_key_env_var="OPENAI_API_KEY"
+            provider="openai", model_name="gpt-4o", api_key_env_var="OPENAI_API_KEY"
         )
 
         # Create client
@@ -262,9 +256,7 @@ class TestLLMFactory:
 
         # Create config for Ollama (no API key needed)
         config = LLMConfig(
-            provider="ollama",
-            model_name="llama2",
-            api_key_env_var="MISSING_KEY"
+            provider="ollama", model_name="llama2", api_key_env_var="MISSING_KEY"
         )
 
         # Should NOT raise error - local models don't need API keys

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -264,12 +264,8 @@ class TestJudgeModels:
     def test_get_score_for_agent(self):
         """Test getting score for specific agent."""
         scores = [
-            AgentScore(
-                agent_id="agent1", agent_name="A", score=8.5, reasoning="Good"
-            ),
-            AgentScore(
-                agent_id="agent2", agent_name="B", score=7.0, reasoning="OK"
-            ),
+            AgentScore(agent_id="agent1", agent_name="A", score=8.5, reasoning="Good"),
+            AgentScore(agent_id="agent2", agent_name="B", score=7.0, reasoning="OK"),
         ]
         result = JudgeResult(
             summary="Test",
@@ -397,7 +393,9 @@ class TestDebateConfig:
             )
         # Check that validation error is about agents list length
         assert "agents" in str(exc_info.value).lower()
-        assert "at least 2" in str(exc_info.value).lower() or "too_short" in str(exc_info.value)
+        assert "at least 2" in str(exc_info.value).lower() or "too_short" in str(
+            exc_info.value
+        )
 
     def test_unique_agent_ids_validation(self):
         """Test that agent IDs must be unique."""

--- a/backend/tests/test_personas.py
+++ b/backend/tests/test_personas.py
@@ -1,0 +1,332 @@
+"""Tests for persona service and API endpoints."""
+import json
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from models.persona import PersonaStyle, PersonaTemplate
+from services.persona_service import PersonaService
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Create test client."""
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def personas_config_path() -> str:
+    """Get path to personas config file."""
+    return str(Path(__file__).parent.parent / "config" / "personas.json")
+
+
+@pytest.fixture
+def temp_personas_file(tmp_path) -> Path:
+    """Create a temporary personas JSON file for testing."""
+    personas_data = [
+        {
+            "persona_id": "test-philosopher",
+            "name": "Test Philosopher",
+            "expertise": "Logic and Testing",
+            "debate_style": "socratic",
+            "description": "A test persona for unit testing",
+            "system_prompt_template": "Test prompt with {stance}",
+            "suggested_temperature": 0.7,
+            "suggested_max_tokens": 1024,
+            "tags": ["test", "philosophy"],
+        },
+        {
+            "persona_id": "test-scientist",
+            "name": "Test Scientist",
+            "expertise": "Data Analysis",
+            "debate_style": "analytical",
+            "description": "Another test persona",
+            "system_prompt_template": "Science prompt {stance}",
+            "suggested_temperature": 0.5,
+            "suggested_max_tokens": 1200,
+            "tags": ["science", "test"],
+        },
+    ]
+
+    personas_file = tmp_path / "personas.json"
+    with open(personas_file, "w", encoding="utf-8") as f:
+        json.dump(personas_data, f)
+
+    return personas_file
+
+
+class TestPersonaService:
+    """Test PersonaService class."""
+
+    def test_load_personas_from_file(self, temp_personas_file):
+        """Test loading personas from JSON file."""
+        service = PersonaService(config_path=str(temp_personas_file))
+
+        assert len(service.personas) == 2
+        assert "test-philosopher" in service.personas
+        assert "test-scientist" in service.personas
+
+    def test_load_personas_with_default_path(self, personas_config_path):
+        """Test loading personas from default config path."""
+        service = PersonaService()
+
+        personas = service.list_personas()
+        assert len(personas) >= 8  # Should have at least 8 starter personas
+        assert all(isinstance(p, PersonaTemplate) for p in personas)
+
+    def test_list_personas(self, temp_personas_file):
+        """Test listing all personas."""
+        service = PersonaService(config_path=str(temp_personas_file))
+        personas = service.list_personas()
+
+        assert len(personas) == 2
+        assert all(isinstance(p, PersonaTemplate) for p in personas)
+
+    def test_get_persona_by_id(self, temp_personas_file):
+        """Test getting specific persona by ID."""
+        service = PersonaService(config_path=str(temp_personas_file))
+
+        persona = service.get_persona("test-philosopher")
+        assert persona is not None
+        assert persona.persona_id == "test-philosopher"
+        assert persona.name == "Test Philosopher"
+        assert persona.expertise == "Logic and Testing"
+        assert persona.debate_style == PersonaStyle.SOCRATIC
+
+    def test_get_nonexistent_persona(self, temp_personas_file):
+        """Test getting persona that doesn't exist."""
+        service = PersonaService(config_path=str(temp_personas_file))
+
+        persona = service.get_persona("nonexistent")
+        assert persona is None
+
+    def test_load_invalid_json(self, tmp_path):
+        """Test handling of invalid JSON file."""
+        invalid_file = tmp_path / "invalid.json"
+        with open(invalid_file, "w", encoding="utf-8") as f:
+            f.write("{ invalid json }")
+
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            PersonaService(config_path=str(invalid_file))
+
+    def test_load_missing_file(self):
+        """Test handling of missing config file."""
+        with pytest.raises(FileNotFoundError, match="not found"):
+            PersonaService(config_path="/nonexistent/path.json")
+
+    def test_skip_invalid_persona(self, tmp_path):
+        """Test that invalid personas are skipped with warning."""
+        personas_data = [
+            {
+                "persona_id": "valid-persona",
+                "name": "Valid Persona",
+                "expertise": "Testing",
+                "debate_style": "analytical",
+                "description": "Valid persona",
+                "system_prompt_template": "Prompt {stance}",
+                "suggested_temperature": 0.7,
+                "suggested_max_tokens": 1024,
+                "tags": ["test"],
+            },
+            {
+                # Missing required fields - should be skipped
+                "persona_id": "invalid-persona",
+                "name": "Invalid",
+            },
+        ]
+
+        personas_file = tmp_path / "mixed.json"
+        with open(personas_file, "w", encoding="utf-8") as f:
+            json.dump(personas_data, f)
+
+        service = PersonaService(config_path=str(personas_file))
+
+        # Should load only the valid persona
+        assert len(service.personas) == 1
+        assert "valid-persona" in service.personas
+        assert "invalid-persona" not in service.personas
+
+    def test_duplicate_persona_id(self, tmp_path):
+        """Test that duplicate persona IDs are handled."""
+        personas_data = [
+            {
+                "persona_id": "duplicate",
+                "name": "First",
+                "expertise": "Testing",
+                "debate_style": "analytical",
+                "description": "First persona",
+                "system_prompt_template": "Prompt {stance}",
+                "suggested_temperature": 0.7,
+                "suggested_max_tokens": 1024,
+                "tags": [],
+            },
+            {
+                "persona_id": "duplicate",
+                "name": "Second",
+                "expertise": "Testing",
+                "debate_style": "socratic",
+                "description": "Second persona",
+                "system_prompt_template": "Different prompt {stance}",
+                "suggested_temperature": 0.5,
+                "suggested_max_tokens": 512,
+                "tags": [],
+            },
+        ]
+
+        personas_file = tmp_path / "duplicates.json"
+        with open(personas_file, "w", encoding="utf-8") as f:
+            json.dump(personas_data, f)
+
+        service = PersonaService(config_path=str(personas_file))
+
+        # Should keep only the first occurrence
+        assert len(service.personas) == 1
+        assert service.personas["duplicate"].name == "First"
+
+
+class TestPersonasAPI:
+    """Test /api/personas endpoints."""
+
+    def test_list_personas_endpoint(self, client):
+        """Test GET /api/personas returns personas catalog."""
+        response = client.get("/api/personas")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify response structure
+        assert "personas" in data
+        assert "total" in data
+        assert isinstance(data["personas"], list)
+        assert data["total"] == len(data["personas"])
+
+        # Verify we have at least 8 starter personas
+        assert len(data["personas"]) >= 8
+
+    def test_personas_have_required_fields(self, client):
+        """Test that all personas have required fields."""
+        response = client.get("/api/personas")
+        assert response.status_code == 200
+
+        personas = response.json()["personas"]
+
+        required_fields = [
+            "persona_id",
+            "name",
+            "expertise",
+            "debate_style",
+            "description",
+            "system_prompt_template",
+            "suggested_temperature",
+            "suggested_max_tokens",
+            "tags",
+        ]
+
+        for persona in personas:
+            for field in required_fields:
+                assert field in persona, f"Missing field {field} in persona {persona.get('name', 'unknown')}"
+
+    def test_persona_ids_are_unique(self, client):
+        """Test that all persona IDs are unique."""
+        response = client.get("/api/personas")
+        assert response.status_code == 200
+
+        personas = response.json()["personas"]
+        persona_ids = [p["persona_id"] for p in personas]
+
+        # Check for uniqueness
+        assert len(persona_ids) == len(set(persona_ids)), "Duplicate persona_id found"
+
+    def test_system_prompt_templates_have_stance_placeholder(self, client):
+        """Test that all system prompt templates include {stance} placeholder."""
+        response = client.get("/api/personas")
+        assert response.status_code == 200
+
+        personas = response.json()["personas"]
+
+        for persona in personas:
+            template = persona["system_prompt_template"]
+            assert (
+                "{stance}" in template
+            ), f"Persona {persona['name']} missing {{stance}} placeholder"
+
+    def test_personas_have_valid_debate_styles(self, client):
+        """Test that all personas have valid debate styles."""
+        response = client.get("/api/personas")
+        assert response.status_code == 200
+
+        personas = response.json()["personas"]
+        valid_styles = ["aggressive", "diplomatic", "analytical", "socratic"]
+
+        for persona in personas:
+            assert (
+                persona["debate_style"] in valid_styles
+            ), f"Invalid debate_style for {persona['name']}: {persona['debate_style']}"
+
+    def test_suggested_parameters_are_valid(self, client):
+        """Test that suggested parameters are within valid ranges."""
+        response = client.get("/api/personas")
+        assert response.status_code == 200
+
+        personas = response.json()["personas"]
+
+        for persona in personas:
+            # Temperature should be between 0 and 2
+            assert (
+                0.0 <= persona["suggested_temperature"] <= 2.0
+            ), f"Invalid temperature for {persona['name']}"
+
+            # Max tokens should be reasonable
+            assert (
+                1 <= persona["suggested_max_tokens"] <= 4096
+            ), f"Invalid max_tokens for {persona['name']}"
+
+
+class TestPersonaCatalogIntegrity:
+    """Test the integrity of the actual personas.json catalog."""
+
+    def test_all_starter_personas_exist(self, client):
+        """Test that all 8 expected starter personas are present."""
+        response = client.get("/api/personas")
+        assert response.status_code == 200
+
+        personas = response.json()["personas"]
+        persona_names = {p["name"] for p in personas}
+
+        expected_personas = {
+            "Socratic Philosopher",
+            "Data Scientist",
+            "Trial Lawyer",
+            "Academic Researcher",
+            "Political Strategist",
+            "Entrepreneur",
+            "Ethicist",
+            "Investigative Journalist",
+        }
+
+        for expected_name in expected_personas:
+            assert (
+                expected_name in persona_names
+            ), f"Missing expected persona: {expected_name}"
+
+    def test_personas_have_meaningful_descriptions(self, client):
+        """Test that personas have non-empty descriptions."""
+        response = client.get("/api/personas")
+        assert response.status_code == 200
+
+        personas = response.json()["personas"]
+
+        for persona in personas:
+            assert (
+                len(persona["description"]) > 10
+            ), f"Persona {persona['name']} has insufficient description"
+            assert (
+                len(persona["expertise"]) > 0
+            ), f"Persona {persona['name']} missing expertise"
+            assert (
+                len(persona["system_prompt_template"]) > 50
+            ), f"Persona {persona['name']} has insufficient prompt template"

--- a/backend/tests/test_personas.py
+++ b/backend/tests/test_personas.py
@@ -228,7 +228,9 @@ class TestPersonasAPI:
 
         for persona in personas:
             for field in required_fields:
-                assert field in persona, f"Missing field {field} in persona {persona.get('name', 'unknown')}"
+                assert (
+                    field in persona
+                ), f"Missing field {field} in persona {persona.get('name', 'unknown')}"
 
     def test_persona_ids_are_unique(self, client):
         """Test that all persona IDs are unique."""

--- a/backend/tests/test_prompt_builder.py
+++ b/backend/tests/test_prompt_builder.py
@@ -20,7 +20,7 @@ def sample_llm_config():
     return LLMConfig(
         provider=ModelProvider.ANTHROPIC,
         model_name="claude-3-5-sonnet-20241022",
-        api_key_env_var="ANTHROPIC_API_KEY"
+        api_key_env_var="ANTHROPIC_API_KEY",
     )
 
 
@@ -35,7 +35,7 @@ def sample_agent(sample_llm_config):
         stance="Pro",
         system_prompt="You are an optimistic technologist who believes AI will benefit humanity.",
         temperature=1.0,
-        max_tokens=1024
+        max_tokens=1024,
     )
 
 
@@ -50,7 +50,7 @@ def sample_judge_config(sample_llm_config):
         stance="Neutral",
         system_prompt="You are a fair and impartial debate judge.",
         temperature=0.7,
-        max_tokens=2048
+        max_tokens=2048,
     )
 
 
@@ -65,7 +65,7 @@ def sample_messages():
             round_number=1,
             turn_number=0,
             stance="Pro",
-            timestamp=datetime.now(timezone.utc)
+            timestamp=datetime.now(timezone.utc),
         ),
         Message(
             agent_id="agent2",
@@ -74,7 +74,7 @@ def sample_messages():
             round_number=1,
             turn_number=1,
             stance="Con",
-            timestamp=datetime.now(timezone.utc)
+            timestamp=datetime.now(timezone.utc),
         ),
     ]
 
@@ -92,7 +92,7 @@ class TestBuildDebaterPrompt:
             agent=sample_agent,
             topic=topic,
             current_round=current_round,
-            total_rounds=total_rounds
+            total_rounds=total_rounds,
         )
 
         # Check that all components are present
@@ -107,10 +107,7 @@ class TestBuildDebaterPrompt:
     def test_build_debater_prompt_structure(self, sample_agent):
         """Test that the prompt has proper structure."""
         prompt = build_debater_prompt(
-            agent=sample_agent,
-            topic="Test topic",
-            current_round=1,
-            total_rounds=3
+            agent=sample_agent, topic="Test topic", current_round=1, total_rounds=3
         )
 
         # Should not have leading/trailing whitespace
@@ -135,7 +132,7 @@ class TestBuildJudgePrompt:
                 stance="Pro",
                 system_prompt="Test",
                 temperature=1.0,
-                max_tokens=1024
+                max_tokens=1024,
             ),
             AgentConfig(
                 agent_id="agent2",
@@ -145,14 +142,12 @@ class TestBuildJudgePrompt:
                 stance="Con",
                 system_prompt="Test",
                 temperature=1.0,
-                max_tokens=1024
+                max_tokens=1024,
             ),
         ]
 
         prompt = build_judge_prompt(
-            topic=topic,
-            agents=agents,
-            judge_config=sample_judge_config
+            topic=topic, agents=agents, judge_config=sample_judge_config
         )
 
         # Check components
@@ -167,7 +162,9 @@ class TestBuildJudgePrompt:
         assert "agent_scores" in prompt
         assert "winner_id" in prompt
 
-    def test_build_judge_prompt_multiple_agents(self, sample_judge_config, sample_llm_config):
+    def test_build_judge_prompt_multiple_agents(
+        self, sample_judge_config, sample_llm_config
+    ):
         """Test judge prompt with multiple agents."""
         agents = [
             AgentConfig(
@@ -178,15 +175,13 @@ class TestBuildJudgePrompt:
                 stance=f"Stance {i}",
                 system_prompt="Test",
                 temperature=1.0,
-                max_tokens=1024
+                max_tokens=1024,
             )
             for i in range(1, 4)
         ]
 
         prompt = build_judge_prompt(
-            topic="Test topic",
-            agents=agents,
-            judge_config=sample_judge_config
+            topic="Test topic", agents=agents, judge_config=sample_judge_config
         )
 
         # All agents should be listed
@@ -200,10 +195,7 @@ class TestFormatHistoryForContext:
     def test_format_history_empty(self):
         """Test formatting with no history."""
         context = format_history_for_context(
-            history=[],
-            topic="Test topic",
-            current_round=1,
-            total_rounds=3
+            history=[], topic="Test topic", current_round=1, total_rounds=3
         )
 
         assert "Test topic" in context
@@ -214,10 +206,7 @@ class TestFormatHistoryForContext:
     def test_format_history_with_messages(self, sample_messages):
         """Test formatting with message history."""
         context = format_history_for_context(
-            history=sample_messages,
-            topic="AI debate",
-            current_round=2,
-            total_rounds=3
+            history=sample_messages, topic="AI debate", current_round=2, total_rounds=3
         )
 
         assert "AI debate" in context
@@ -231,10 +220,7 @@ class TestFormatHistoryForContext:
     def test_format_history_message_order(self, sample_messages):
         """Test that messages are in correct order."""
         context = format_history_for_context(
-            history=sample_messages,
-            topic="Test",
-            current_round=2,
-            total_rounds=3
+            history=sample_messages, topic="Test", current_round=2, total_rounds=3
         )
 
         # First message should appear before second
@@ -245,10 +231,7 @@ class TestFormatHistoryForContext:
     def test_format_history_includes_round_and_turn(self, sample_messages):
         """Test that round and turn numbers are included."""
         context = format_history_for_context(
-            history=sample_messages,
-            topic="Test",
-            current_round=2,
-            total_rounds=3
+            history=sample_messages, topic="Test", current_round=2, total_rounds=3
         )
 
         assert "[Round 1, Turn 1]" in context
@@ -261,10 +244,7 @@ class TestFormatHistoryForJudge:
     def test_format_history_for_judge(self, sample_messages):
         """Test formatting complete history for judge."""
         topic = "AI debate topic"
-        context = format_history_for_judge(
-            history=sample_messages,
-            topic=topic
-        )
+        context = format_history_for_judge(history=sample_messages, topic=topic)
 
         assert topic in context
         assert "FULL TRANSCRIPT:" in context
@@ -277,20 +257,14 @@ class TestFormatHistoryForJudge:
 
     def test_format_history_for_judge_separator(self, sample_messages):
         """Test that messages are separated properly."""
-        context = format_history_for_judge(
-            history=sample_messages,
-            topic="Test"
-        )
+        context = format_history_for_judge(history=sample_messages, topic="Test")
 
         # Should have separator between messages
         assert "---" in context
 
     def test_format_history_for_judge_empty(self):
         """Test formatting with empty history."""
-        context = format_history_for_judge(
-            history=[],
-            topic="Test topic"
-        )
+        context = format_history_for_judge(history=[], topic="Test topic")
 
         assert "Test topic" in context
         assert "FULL TRANSCRIPT:" in context

--- a/frontend/e2e/helpers/debate-helpers.ts
+++ b/frontend/e2e/helpers/debate-helpers.ts
@@ -7,7 +7,7 @@ import { Page, expect } from '@playwright/test';
 
 export interface WebSocketMessage {
   type: string;
-  payload?: any;
+  payload?: unknown;
   timestamp?: string;
 }
 

--- a/frontend/e2e/persona-feature.spec.ts
+++ b/frontend/e2e/persona-feature.spec.ts
@@ -1,0 +1,299 @@
+/**
+ * Persona Feature E2E Test
+ *
+ * Tests the complete persona selection and integration flow.
+ *
+ * Prerequisites:
+ * - Backend must be running
+ * - Ollama must be running with mistral model
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Persona Feature', () => {
+  test('Persona selector loads and populates form', async ({ page }) => {
+    // Navigate to application
+    await page.goto('/');
+
+    // Remove any existing default agents
+    const removeButtons = page.locator('button:has-text("Remove")');
+    const removeCount = await removeButtons.count();
+    for (let i = 0; i < removeCount; i++) {
+      await removeButtons.first().click();
+      await page.waitForTimeout(300);
+    }
+
+    // Open Add Agent modal
+    await page.click('button:has-text("Add Agent")');
+    await page.waitForSelector('dialog:has-text("Add Participant")', {
+      timeout: 5000,
+    });
+
+    // Wait for persona selector to load
+    await page.waitForSelector('label:has-text("Persona Template")', {
+      timeout: 5000,
+    });
+
+    // Verify persona selector is visible and has loaded options
+    const personaSelect = page.locator('select', {
+      has: page.locator('option:has-text("Socratic Philosopher")'),
+    });
+    await expect(personaSelect).toBeVisible();
+
+    // Verify "None (Custom)" option exists
+    await expect(
+      personaSelect.locator('option:has-text("None (Custom)")')
+    ).toBeVisible();
+
+    // Verify all expected personas are loaded
+    const expectedPersonas = [
+      'Socratic Philosopher',
+      'Data Scientist',
+      'Trial Lawyer',
+      'Academic Researcher',
+      'Political Strategist',
+      'Entrepreneur',
+      'Ethicist',
+      'Investigative Journalist',
+    ];
+
+    for (const personaName of expectedPersonas) {
+      await expect(
+        personaSelect.locator(`option:has-text("${personaName}")`)
+      ).toBeVisible();
+    }
+
+    // Select "Socratic Philosopher" persona
+    await personaSelect.selectOption({ label: 'Socratic Philosopher' });
+    await page.waitForTimeout(500); // Allow form to update
+
+    // Verify persona details card appears
+    await expect(
+      page.locator('text=Logic and Epistemology')
+    ).toBeVisible();
+    await expect(
+      page.locator('text=Questions assumptions, seeks truth through inquiry')
+    ).toBeVisible();
+
+    // Verify form fields are populated
+    const agentNameInput = page.locator('input[placeholder*="Agent" i]');
+    await expect(agentNameInput).toHaveValue('Socratic Philosopher');
+
+    // Verify system prompt is populated and contains persona-specific content
+    const systemPromptTextarea = page.locator('textarea');
+    const promptValue = await systemPromptTextarea.inputValue();
+    expect(promptValue).toContain('philosopher');
+    expect(promptValue).toContain('Socratic');
+
+    // Verify temperature field is set to persona's suggested value (0.7)
+    const temperatureInput = page.locator('input[label*="Temperature" i]');
+    const tempValue = await temperatureInput.inputValue();
+    expect(parseFloat(tempValue)).toBeCloseTo(0.7, 1);
+
+    // Verify max tokens field is set
+    const maxTokensInput = page.locator('input[label*="Max Tokens" i]');
+    const tokensValue = await maxTokensInput.inputValue();
+    expect(parseInt(tokensValue)).toBe(1024);
+
+    // Verify fields are still editable - change agent name
+    await agentNameInput.clear();
+    await agentNameInput.fill('Custom Philosopher Name');
+    await expect(agentNameInput).toHaveValue('Custom Philosopher Name');
+
+    // Close modal
+    await page.click('button:has-text("Cancel")');
+  });
+
+  test('Persona selection updates prompt when stance changes', async ({
+    page,
+  }) => {
+    // Navigate and open modal
+    await page.goto('/');
+
+    const removeButtons = page.locator('button:has-text("Remove")');
+    const removeCount = await removeButtons.count();
+    for (let i = 0; i < removeCount; i++) {
+      await removeButtons.first().click();
+      await page.waitForTimeout(300);
+    }
+
+    await page.click('button:has-text("Add Agent")');
+    await page.waitForSelector('dialog:has-text("Add Participant")');
+
+    // Select a persona
+    const personaSelect = page.locator('select', {
+      has: page.locator('option:has-text("Trial Lawyer")'),
+    });
+    await personaSelect.selectOption({ label: 'Trial Lawyer' });
+    await page.waitForTimeout(500);
+
+    // Get initial system prompt
+    const systemPromptTextarea = page.locator('textarea');
+    const initialPrompt = await systemPromptTextarea.inputValue();
+
+    // Change stance from Pro to Con
+    const stanceSelect = page.locator('select', {
+      has: page.locator('option:has-text("Con")'),
+    });
+    await stanceSelect.selectOption({ label: 'Con (Against)' });
+    await page.waitForTimeout(500);
+
+    // Verify system prompt updated with new stance
+    const updatedPrompt = await systemPromptTextarea.inputValue();
+    expect(updatedPrompt).toContain('Con');
+    expect(updatedPrompt).not.toEqual(initialPrompt);
+
+    await page.click('button:has-text("Cancel")');
+  });
+
+  test('Can create agent with persona and run debate', async ({ page }) => {
+    // Set a longer timeout for this test since it runs a debate
+    test.setTimeout(120000);
+
+    await page.goto('/');
+
+    // Set topic
+    const topicInput = page.locator('textarea[placeholder*="topic" i]');
+    await topicInput.clear();
+    await topicInput.fill('Is philosophy still relevant in modern society?');
+
+    // Remove default agents
+    const removeButtons = page.locator('button:has-text("Remove")');
+    const removeCount = await removeButtons.count();
+    for (let i = 0; i < removeCount; i++) {
+      await removeButtons.first().click();
+      await page.waitForTimeout(300);
+    }
+
+    // Add Agent 1 with Socratic Philosopher persona
+    await page.click('button:has-text("Add Agent")');
+    await page.waitForSelector('dialog:has-text("Add Participant")');
+
+    // Select Socratic Philosopher
+    const personaSelect1 = page.locator('select', {
+      has: page.locator('option:has-text("Socratic Philosopher")'),
+    });
+    await personaSelect1.selectOption({ label: 'Socratic Philosopher' });
+    await page.waitForTimeout(500);
+
+    // Select Ollama provider and model
+    await page.selectOption(
+      'select[id*="provider" i], label:has-text("Provider") + select',
+      { label: 'Ollama' }
+    );
+    await page.waitForTimeout(500);
+    await page.selectOption(
+      'select[id*="model" i], label:has-text("Model") + select',
+      { label: 'Mistral 7B' }
+    );
+
+    await page.click('button:has-text("Add Agent"):not(:has-text("Cancel"))');
+    await page.waitForTimeout(500);
+
+    // Add Agent 2 with Data Scientist persona
+    await page.click('button:has-text("Add Agent")');
+    await page.waitForSelector('dialog:has-text("Add Participant")');
+
+    const personaSelect2 = page.locator('select', {
+      has: page.locator('option:has-text("Data Scientist")'),
+    });
+    await personaSelect2.selectOption({ label: 'Data Scientist' });
+    await page.waitForTimeout(500);
+
+    // Change stance to Con
+    await page.selectOption('select:has-text("Con")', {
+      label: 'Con (Against)',
+    });
+
+    // Select Ollama provider and model
+    await page.selectOption(
+      'select[id*="provider" i], label:has-text("Provider") + select',
+      { label: 'Ollama' }
+    );
+    await page.waitForTimeout(500);
+    await page.selectOption(
+      'select[id*="model" i], label:has-text("Model") + select',
+      { label: 'Mistral 7B' }
+    );
+
+    await page.click('button:has-text("Add Agent"):not(:has-text("Cancel"))');
+    await page.waitForTimeout(500);
+
+    // Verify both agents are added with correct names
+    await expect(page.locator('text=Socratic Philosopher')).toBeVisible();
+    await expect(page.locator('text=Data Scientist')).toBeVisible();
+
+    // Select judge
+    await page.selectOption('select', { label: 'Mistral 7B (Ollama)' });
+
+    // Set rounds to 1 for faster testing
+    const roundsInput = page.locator('input[type="number"]');
+    await roundsInput.clear();
+    await roundsInput.fill('1');
+
+    // Start debate
+    await page.click('button:has-text("Start Debate")');
+
+    // Wait for debate to start
+    await expect(page.locator('text=/Round 1/i')).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Wait for first agent response
+    await expect(
+      page.locator('text=/Socratic Philosopher|Data Scientist/i').first()
+    ).toBeVisible({ timeout: 30000 });
+
+    // Wait for debate to complete (with generous timeout)
+    await page.waitForSelector('text=/Winner|Debate Complete/i', {
+      timeout: 90000,
+    });
+
+    // Verify debate completed successfully
+    await expect(page.locator('text=/Winner|verdict/i')).toBeVisible();
+  });
+
+  test('Custom mode works when no persona selected', async ({ page }) => {
+    await page.goto('/');
+
+    const removeButtons = page.locator('button:has-text("Remove")');
+    const removeCount = await removeButtons.count();
+    for (let i = 0; i < removeCount; i++) {
+      await removeButtons.first().click();
+      await page.waitForTimeout(300);
+    }
+
+    await page.click('button:has-text("Add Agent")');
+    await page.waitForSelector('dialog:has-text("Add Participant")');
+
+    // Ensure "None (Custom)" is selected
+    const personaSelect = page.locator('select', {
+      has: page.locator('option:has-text("None (Custom)")'),
+    });
+    await personaSelect.selectOption({ label: 'None (Custom)' });
+    await page.waitForTimeout(300);
+
+    // Verify no persona details card is shown
+    await expect(page.locator('text=Logic and Epistemology')).not.toBeVisible();
+
+    // Manually fill in agent details
+    const agentNameInput = page.locator('input[placeholder*="Agent" i]');
+    await agentNameInput.fill('Custom Agent');
+
+    // Verify system prompt is empty (using default placeholder behavior)
+    const systemPromptTextarea = page.locator('textarea');
+    const promptValue = await systemPromptTextarea.inputValue();
+    expect(promptValue).toBe('');
+
+    // Verify temperature and max tokens are at default values
+    const temperatureInput = page.locator('input[label*="Temperature" i]');
+    const tempValue = await temperatureInput.inputValue();
+    expect(parseFloat(tempValue)).toBe(1.0);
+
+    const maxTokensInput = page.locator('input[label*="Max Tokens" i]');
+    const tokensValue = await maxTokensInput.inputValue();
+    expect(parseInt(tokensValue)).toBe(1024);
+
+    await page.click('button:has-text("Cancel")');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "type-check": "tsc --noEmit",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -3,4 +3,6 @@ export type { CreateDebateResponse, StartDebateResponse, ExportFormat } from './
 
 export { providersApi } from './providers';
 
+export { personasApi } from './personas';
+
 export { API_BASE_URL, WS_BASE_URL } from './config';

--- a/frontend/src/api/personas.ts
+++ b/frontend/src/api/personas.ts
@@ -1,0 +1,18 @@
+/**
+ * Persona catalog API client
+ */
+
+import { apiFetch } from './config';
+import type { PersonaCatalogResponse } from '../types/persona';
+
+/**
+ * Personas API methods
+ */
+export const personasApi = {
+  /**
+   * Get all available persona templates
+   */
+  list: async (): Promise<PersonaCatalogResponse> => {
+    return apiFetch<PersonaCatalogResponse>('/api/personas');
+  },
+};

--- a/frontend/src/components/organisms/DebateConfig/AddParticipantModal.tsx
+++ b/frontend/src/components/organisms/DebateConfig/AddParticipantModal.tsx
@@ -4,6 +4,8 @@ import { X } from 'lucide-react';
 import { Button, Input, Select, LoadingSpinner } from '../../atoms';
 import { providersApi } from '../../../api';
 import { AgentConfig, AgentRole, ModelProvider, ProviderInfo } from '../../../types';
+import { PersonaSelector } from './PersonaSelector';
+import { PersonaTemplate } from '../../../types/persona';
 
 export interface AddParticipantModalProps {
   /**
@@ -31,6 +33,7 @@ export const AddParticipantModal: React.FC<AddParticipantModalProps> = ({
   const [isLoading, setIsLoading] = useState(true);
   const [selectedProvider, setSelectedProvider] = useState<string>('');
   const [selectedModel, setSelectedModel] = useState<string>('');
+  const [selectedPersona, setSelectedPersona] = useState<PersonaTemplate | null>(null);
   const [agentName, setAgentName] = useState('');
   const [stance, setStance] = useState('Pro');
   const [systemPrompt, setSystemPrompt] = useState('');
@@ -64,6 +67,28 @@ export const AddParticipantModal: React.FC<AddParticipantModalProps> = ({
     }
   }, [isOpen]);
 
+  const handlePersonaChange = (persona: PersonaTemplate | null) => {
+    setSelectedPersona(persona);
+
+    if (persona) {
+      // Auto-populate form fields from persona template
+      setAgentName(persona.name);
+      setSystemPrompt(persona.system_prompt_template.replace('{stance}', stance));
+      setTemperature(persona.suggested_temperature);
+      setMaxTokens(persona.suggested_max_tokens);
+    } else {
+      // Reset to default when persona is cleared
+      // Don't clear agentName or stance as user may have customized them
+    }
+  };
+
+  // Update system prompt when stance changes and persona is selected
+  useEffect(() => {
+    if (selectedPersona && systemPrompt.includes('{stance}')) {
+      setSystemPrompt(selectedPersona.system_prompt_template.replace('{stance}', stance));
+    }
+  }, [stance, selectedPersona]);
+
   const handleSubmit = () => {
     if (!agentName.trim() || !selectedProvider || !selectedModel) {
       return;
@@ -92,6 +117,7 @@ export const AddParticipantModal: React.FC<AddParticipantModalProps> = ({
     onSubmit(agentConfig);
 
     // Reset form
+    setSelectedPersona(null);
     setAgentName('');
     setStance('Pro');
     setSystemPrompt('');
@@ -136,6 +162,13 @@ export const AddParticipantModal: React.FC<AddParticipantModalProps> = ({
               </div>
             ) : (
               <div className="flex flex-col gap-4">
+                {/* Persona Selector */}
+                <PersonaSelector
+                  value={selectedPersona?.persona_id || null}
+                  onChange={handlePersonaChange}
+                  stance={stance}
+                />
+
                 {/* Agent Name */}
                 <Input
                   label="Agent Name"

--- a/frontend/src/components/organisms/DebateConfig/AddParticipantModal.tsx
+++ b/frontend/src/components/organisms/DebateConfig/AddParticipantModal.tsx
@@ -87,6 +87,7 @@ export const AddParticipantModal: React.FC<AddParticipantModalProps> = ({
     if (selectedPersona && systemPrompt.includes('{stance}')) {
       setSystemPrompt(selectedPersona.system_prompt_template.replace('{stance}', stance));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stance, selectedPersona]);
 
   const handleSubmit = () => {
@@ -166,7 +167,6 @@ export const AddParticipantModal: React.FC<AddParticipantModalProps> = ({
                 <PersonaSelector
                   value={selectedPersona?.persona_id || null}
                   onChange={handlePersonaChange}
-                  stance={stance}
                 />
 
                 {/* Agent Name */}

--- a/frontend/src/components/organisms/DebateConfig/PersonaSelector.tsx
+++ b/frontend/src/components/organisms/DebateConfig/PersonaSelector.tsx
@@ -13,11 +13,6 @@ export interface PersonaSelectorProps {
    * Change handler - receives full persona object or null for custom
    */
   onChange: (persona: PersonaTemplate | null) => void;
-
-  /**
-   * Current stance for prompt preview
-   */
-  stance: string;
 }
 
 /**
@@ -41,7 +36,6 @@ const getStyleBadgeColor = (style: PersonaStyle): 'pro' | 'con' | 'judge' | 'neu
 export const PersonaSelector: React.FC<PersonaSelectorProps> = ({
   value,
   onChange,
-  stance,
 }) => {
   const [personas, setPersonas] = useState<PersonaTemplate[]>([]);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/components/organisms/DebateConfig/PersonaSelector.tsx
+++ b/frontend/src/components/organisms/DebateConfig/PersonaSelector.tsx
@@ -1,0 +1,174 @@
+import React, { useState, useEffect } from 'react';
+import { Select, LoadingSpinner, Badge } from '../../atoms';
+import { personasApi } from '../../../api/personas';
+import { PersonaTemplate, PersonaStyle } from '../../../types/persona';
+
+export interface PersonaSelectorProps {
+  /**
+   * Selected persona ID (null for custom)
+   */
+  value: string | null;
+
+  /**
+   * Change handler - receives full persona object or null for custom
+   */
+  onChange: (persona: PersonaTemplate | null) => void;
+
+  /**
+   * Current stance for prompt preview
+   */
+  stance: string;
+}
+
+/**
+ * Map persona style to badge variant
+ */
+const getStyleBadgeColor = (style: PersonaStyle): 'pro' | 'con' | 'judge' | 'neutral' => {
+  switch (style) {
+    case PersonaStyle.AGGRESSIVE:
+      return 'con'; // Red
+    case PersonaStyle.DIPLOMATIC:
+      return 'judge'; // Purple
+    case PersonaStyle.ANALYTICAL:
+      return 'pro'; // Green
+    case PersonaStyle.SOCRATIC:
+      return 'neutral'; // Slate
+    default:
+      return 'neutral';
+  }
+};
+
+export const PersonaSelector: React.FC<PersonaSelectorProps> = ({
+  value,
+  onChange,
+  stance,
+}) => {
+  const [personas, setPersonas] = useState<PersonaTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPersonas = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await personasApi.list();
+        setPersonas(response.personas);
+      } catch (err) {
+        console.error('Failed to fetch personas:', err);
+        setError('Failed to load personas. Using custom mode.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPersonas();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedId = e.target.value;
+
+    if (!selectedId || selectedId === 'custom') {
+      onChange(null);
+      return;
+    }
+
+    const selectedPersona = personas.find((p) => p.persona_id === selectedId);
+    if (selectedPersona) {
+      onChange(selectedPersona);
+    }
+  };
+
+  const selectedPersona = value ? personas.find((p) => p.persona_id === value) : null;
+
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-slate-200">Persona Template</label>
+        <div className="flex items-center justify-center py-4 rounded-lg border border-slate-700 bg-slate-900">
+          <LoadingSpinner size="sm" color="slate" />
+          <span className="ml-2 text-sm text-slate-400">Loading personas...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-slate-200">Persona Template</label>
+        <div className="rounded-lg border border-yellow-500/20 bg-yellow-500/10 px-3 py-2">
+          <p className="text-sm text-yellow-500">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const options = [
+    { value: 'custom', label: 'None (Custom)' },
+    ...personas.map((persona) => ({
+      value: persona.persona_id,
+      label: persona.name,
+    })),
+  ];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Select
+        label="Persona Template (Optional)"
+        value={value || 'custom'}
+        onChange={handleChange}
+        options={options}
+        helperText="Select a preconfigured persona or create a custom agent"
+        fullWidth
+      />
+
+      {/* Show persona details if one is selected */}
+      {selectedPersona && (
+        <div className="rounded-lg border border-slate-700 bg-slate-900/50 p-4">
+          <div className="flex items-start justify-between gap-3 mb-2">
+            <div className="flex-1">
+              <h4 className="text-sm font-semibold text-slate-100">
+                {selectedPersona.name}
+              </h4>
+              <p className="text-xs text-slate-400 mt-0.5">
+                {selectedPersona.expertise}
+              </p>
+            </div>
+            <Badge
+              variant={getStyleBadgeColor(selectedPersona.debate_style)}
+              size="sm"
+            >
+              {selectedPersona.debate_style}
+            </Badge>
+          </div>
+
+          <p className="text-sm text-slate-300 mb-3">
+            {selectedPersona.description}
+          </p>
+
+          {/* Show tags if available */}
+          {selectedPersona.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {selectedPersona.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-2 py-0.5 text-xs rounded bg-slate-800 text-slate-400 border border-slate-700"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Info message */}
+          <div className="mt-3 pt-3 border-t border-slate-700">
+            <p className="text-xs text-slate-400">
+              ℹ️ All fields below can be customized after selecting a persona
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useAutoScroll.ts
+++ b/frontend/src/hooks/useAutoScroll.ts
@@ -3,7 +3,7 @@
  * Automatically scrolls to bottom when dependencies change (e.g., new messages)
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback, type DependencyList } from 'react';
 
 interface UseAutoScrollOptions {
   /** Enable or disable auto-scroll */
@@ -26,7 +26,7 @@ interface UseAutoScrollOptions {
  * return <div ref={containerRef}>...</div>;
  */
 export function useAutoScroll<T extends HTMLElement = HTMLDivElement>(
-  dependencies: any[],
+  dependencies: DependencyList,
   options: UseAutoScrollOptions = {}
 ): React.RefObject<T> {
   const {
@@ -42,7 +42,7 @@ export function useAutoScroll<T extends HTMLElement = HTMLDivElement>(
   /**
    * Check if user has scrolled away from bottom
    */
-  const checkScrollPosition = () => {
+  const checkScrollPosition = useCallback(() => {
     if (!containerRef.current) return;
 
     const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
@@ -50,7 +50,7 @@ export function useAutoScroll<T extends HTMLElement = HTMLDivElement>(
 
     // If user scrolled more than threshold away from bottom, disable auto-scroll
     isUserScrollingRef.current = distanceFromBottom > threshold;
-  };
+  }, [threshold]);
 
   /**
    * Scroll to bottom of container
@@ -94,7 +94,7 @@ export function useAutoScroll<T extends HTMLElement = HTMLDivElement>(
         clearTimeout(scrollTimeoutRef.current);
       }
     };
-  }, [enabled]);
+  }, [enabled, checkScrollPosition]);
 
   /**
    * Auto-scroll when dependencies change

--- a/frontend/src/hooks/useDebateWebSocket.ts
+++ b/frontend/src/hooks/useDebateWebSocket.ts
@@ -25,7 +25,7 @@ import {
 interface WebSocketMessage {
   type: string;
   debate_id: string;
-  payload: any;
+  payload: unknown;
   timestamp: string;
 }
 
@@ -65,7 +65,6 @@ export function useDebateWebSocket(
 
   // Store actions
   const {
-    setDebate,
     updateDebateStatus,
     setCurrentRound,
     setCurrentTurn,
@@ -89,7 +88,7 @@ export function useDebateWebSocket(
    * Log debug messages if debug mode is enabled
    */
   const log = useCallback(
-    (...args: any[]) => {
+    (...args: unknown[]) => {
       if (debug) {
         console.log('[useDebateWebSocket]', ...args);
       }
@@ -276,6 +275,7 @@ export function useDebateWebSocket(
         );
       }
     }, reconnectDelayRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [log, setConnectionState]);
 
   /**

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -21,6 +21,9 @@ export { DebateStatus, type DebateConfig, type DebateState } from './debate';
 // Provider catalog types
 export { type ModelInfo, type ProviderInfo, type ProviderCatalogResponse } from './provider';
 
+// Persona types
+export { PersonaStyle, type PersonaTemplate, type PersonaCatalogResponse } from './persona';
+
 // WebSocket types
 export {
   WebSocketEventType,

--- a/frontend/src/types/persona.ts
+++ b/frontend/src/types/persona.ts
@@ -1,0 +1,27 @@
+/**
+ * Persona models - mirrors backend/models/persona.py
+ */
+
+export enum PersonaStyle {
+  AGGRESSIVE = 'aggressive',
+  DIPLOMATIC = 'diplomatic',
+  ANALYTICAL = 'analytical',
+  SOCRATIC = 'socratic',
+}
+
+export interface PersonaTemplate {
+  persona_id: string;
+  name: string;
+  expertise: string;
+  debate_style: PersonaStyle;
+  description: string;
+  system_prompt_template: string;
+  suggested_temperature: number;
+  suggested_max_tokens: number;
+  tags: string[];
+}
+
+export interface PersonaCatalogResponse {
+  personas: PersonaTemplate[];
+  total: number;
+}

--- a/frontend/src/types/websocket.ts
+++ b/frontend/src/types/websocket.ts
@@ -9,7 +9,7 @@ import { Message } from './message';
 // Base WebSocket message structure
 export interface WebSocketMessage {
   type: string;
-  payload: Record<string, any>;
+  payload: Record<string, unknown>;
   timestamp: string; // ISO format
 }
 


### PR DESCRIPTION
## Summary

Adds a persona template system that allows users to quickly configure debate agents with expert archetypes. Users can select from 8 preconfigured personas (Socratic Philosopher, Trial Lawyer, Data Scientist, etc.) that automatically populate agent configuration with appropriate expertise, debate style, and system prompts.

**Key Features:**
- 🎭 8 expert persona templates with distinct debate styles
- 🔄 Auto-populates agent name, system prompt, temperature, and max tokens
- ✏️ All fields remain fully editable after persona selection
- 🔙 Backward compatible - custom agent creation still works
- 📊 Persona details displayed with style badges and tags

## Implementation

### Backend
- **Models:** `PersonaTemplate`, `PersonaCatalogResponse` with validation
- **Service:** `PersonaService` loads personas from JSON config
- **API:** `GET /api/personas` endpoint returns catalog
- **Config:** 8 starter personas in `backend/config/personas.json`

### Frontend
- **Component:** `PersonaSelector` with loading/error states
- **Integration:** Added to `AddParticipantModal` as first field
- **Auto-fill:** Updates form when persona selected or stance changes
- **Types:** TypeScript types mirror backend models

### Testing
- ✅ 17 backend unit tests (100% passing)
- ✅ Comprehensive E2E tests with Playwright
- ✅ API endpoint validation
- ✅ Catalog integrity checks

## Test Plan

- [x] Backend tests pass (`poetry run pytest tests/test_personas.py`)
- [x] GET /api/personas returns 8 personas
- [x] TypeScript compiles without errors
- [x] Persona selector loads in UI
- [x] Form auto-populates when persona selected
- [x] Fields remain editable after selection
- [x] Custom mode works (backward compatible)
- [x] E2E tests cover full persona flow

## Screenshots

The persona selector appears at the top of the Add Agent modal:
- Dropdown with 8 personas + "None (Custom)" option
- Persona details card shows expertise, style badge, description, and tags
- Info message confirms all fields are editable

## Personas Included

1. **Socratic Philosopher** - Logic & reasoning, socratic questioning
2. **Data Scientist** - Statistical analysis, empirical evidence
3. **Trial Lawyer** - Rhetoric, aggressive persuasion
4. **Academic Researcher** - Scholarly rigor, cautious analysis
5. **Political Strategist** - Public opinion framing, diplomatic
6. **Entrepreneur** - Innovation, first principles thinking
7. **Ethicist** - Moral philosophy, principle-driven
8. **Investigative Journalist** - Fact-checking, skeptical inquiry

## Breaking Changes

None. This is purely additive - existing agent creation flow unchanged.

## Future Enhancements (not in this PR)

- User-created custom personas
- Persona analytics (usage, win rates)
- Persona recommendations based on topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)